### PR TITLE
fixed constructor issues, added iteration interface

### DIFF
--- a/src/CombinatorialCodes/CombinatorialCodes.jl
+++ b/src/CombinatorialCodes/CombinatorialCodes.jl
@@ -78,6 +78,26 @@ end
 
 ###############################################################################################
 
+#################
+# ITERATION
+#################
+function start(CC::CombinatorialCode)
+  return 1
+end
+function next(CC::CombinatorialCode, state)
+  return (CC.words[state], state+1)
+end
+function done(CC::CombinatorialCode, state)
+  return state > length(CC.words)
+end
+function eltype(::CombinatorialCode)
+  return CodeWord
+end
+function length(CC::CombinatorialCode)
+  return length(CC.words)
+end
+
+
 
 # This is a function that detects if the code has the empty set:
 HasEmptySet(code::CombinatorialCode)=in(emptyset,code)

--- a/src/CombinatorialCodes/CombinatorialCodes.jl
+++ b/src/CombinatorialCodes/CombinatorialCodes.jl
@@ -1,61 +1,61 @@
 ###################### This is the type that defines combinatorial codes
 type CombinatorialCode
-                words::Array{CodeWord,1}   # the codewords, these are ordered by the weights (in the increasing order)
-                weights::Array{Int,1} # the sizes of the codewords in the same order as the words
-                MaximumWeight::Int  #
-                Minimumweight::Int  #
-                Nwords::Int       	# total number of codewords in the code
-                vertices::CodeWord 	# the set of all vertices that show up in the code
+  words::Array{CodeWord,1}   # the codewords, these are ordered by the weights (in the increasing order)
+  weights::Array{Int,1} # the sizes of the codewords in the same order as the words
+  MaximumWeight::Int  #
+  Minimumweight::Int  #
+  Nwords::Int       	# total number of codewords in the code
+  vertices::CodeWord 	# the set of all vertices that show up in the code
   ## this is the constructor for the CombinatorialCode type. It takes a list of Integer arrays, where each array represents a codeword
   ## codewords are checked for duplication
 
   # The following function constructs a combinatorial code from a list of words
-  function CombinatorialCode(ListOfWords::Array{Any,1})
-           if length(ListOfWords)<1; println("WARNING: The void code was passed!!");
-               return new([], Array{Int,1}([]),-1,-1,0,emptyset)
-           end
-           vertices=emptyset # keep track of all the vertices here
-           # First, compute the weights
-           weights=zeros(Int,length(ListOfWords))
-           for i=1:length(ListOfWords)
-            weights[i]=length(unique(ListOfWords[i]))
-           end
-           MaximumWeight=maximum(weights)
-           Minimumweight=minimum(weights)
-           # next we figure out if there are any duplicate words in the list and populate the list of sets named words
-           words=CodeWord[];
-           ThereWereDuplicates=false
-           for w= Minimumweight:MaximumWeight
-               Ind=find(weights.==w);
-               L=length(Ind);
-                if L>0
-               	   CurrentListOfWords=CodeWord[];
-               # if there was more than one word with the same weights we check the repeated words
-               	  for j=1:L
-               	  	    CurrentSet=CodeWord((ListOfWords[Ind[j]]))
-                        CurrentSetIsDuplicated=false
-                        for k=1:length(CurrentListOfWords) # check the previous words of the same weight is duplicated, if yes, then discard the CurrentSet
-                        	if CurrentListOfWords[k]==CurrentSet
-                        		    CurrentSetIsDuplicated=true
-                                ThereWereDuplicates=true
-                        		break
-                        	end
-                        end
-                        if ~CurrentSetIsDuplicated
-                        push!(CurrentListOfWords,CurrentSet)
-                        push!(words,CurrentSet)
-                        vertices=union(vertices,CurrentSet)
-                        end
-               	    end
-                 end
-            end
-            Nwords=length(words)
-            # now we recompute the weights for possibly reduced list, since we removed all the duplicates
-            weights=zeros(Int,Nwords)
-            for i=1:Nwords ; weights[i]=length(words[i]); end
-           if ThereWereDuplicates println("Warning: There were duplicated words") end
-           new(words,weights,MaximumWeight,Minimumweight,Nwords,vertices)
+  function CombinatorialCode(ListOfWords::Vector)
+    if length(ListOfWords)<1; println("WARNING: The void code was passed!!");
+      return new([], Array{Int,1}([]),-1,-1,0,emptyset)
+    end
+    vertices=emptyset # keep track of all the vertices here
+    # First, compute the weights
+    weights=zeros(Int,length(ListOfWords))
+    for i=1:length(ListOfWords)
+    weights[i]=length(unique(ListOfWords[i]))
+    end
+    MaximumWeight=maximum(weights)
+    Minimumweight=minimum(weights)
+    # next we figure out if there are any duplicate words in the list and populate the list of sets named words
+    words=CodeWord[];
+    ThereWereDuplicates=false
+    for w= Minimumweight:MaximumWeight
+      Ind=find(weights.==w);
+      L=length(Ind);
+      if L>0
+        CurrentListOfWords=CodeWord[];
+        # if there was more than one word with the same weights we check the repeated words
+        for j=1:L
+          CurrentSet=CodeWord((ListOfWords[Ind[j]]))
+          CurrentSetIsDuplicated=false
+          for k=1:length(CurrentListOfWords) # check the previous words of the same weight is duplicated, if yes, then discard the CurrentSet
+          	if CurrentListOfWords[k]==CurrentSet
+              CurrentSetIsDuplicated=true
+              ThereWereDuplicates=true
+          		break
+          	end
+          end
+          if ~CurrentSetIsDuplicated
+          push!(CurrentListOfWords,CurrentSet)
+          push!(words,CurrentSet)
+          vertices=union(vertices,CurrentSet)
+          end
         end
+      end
+    end
+    Nwords=length(words)
+    # now we recompute the weights for possibly reduced list, since we removed all the duplicates
+    weights=zeros(Int,Nwords)
+    for i=1:Nwords ; weights[i]=length(words[i]); end
+    if ThereWereDuplicates println("Warning: There were duplicated words") end
+    new(words,weights,MaximumWeight,Minimumweight,Nwords,vertices)
+  end
 
 
 """

--- a/src/CombinatorialCodes/CombinatorialCodes.jl
+++ b/src/CombinatorialCodes/CombinatorialCodes.jl
@@ -93,6 +93,9 @@ end
 function eltype(::CombinatorialCode)
   return CodeWord
 end
+function eltype(::Type{CombinatorialCode})
+  return CodeWord
+end
 function length(CC::CombinatorialCode)
   return length(CC.words)
 end

--- a/src/Simplicial.jl
+++ b/src/Simplicial.jl
@@ -2,6 +2,7 @@ __precompile__(true)
 module Simplicial
 using Combinatorics, Plotly
 import Base.in, Base.==, Base.<=, Base.show, Base.push!, Base.transpose
+import Base: start, next, done, eltype, length
 map(include,
     ["ImportantConstants.jl", # definition for the type of CodeWord and the related methods for this type
      "CombinatorialCodes/CombinatorialCodes.jl",
@@ -38,6 +39,7 @@ export MaximalDimension, MaximalHomologicalDimension
 export TwoTorus, KleinBottle, PoincareHomologyThreeSphere,DunceHat
 export PlotBettiCurves
 export hvector
+export start, next, done, eltype, length
 # definitions related to directed complexes
 export DirectedCodeword, issubsequence, DirectedComplex, Matrix2Permutations
 export GradedPoset, BoundaryOperator

--- a/src/SimplicialComplexes/SimplicialComplex.jl
+++ b/src/SimplicialComplexes/SimplicialComplex.jl
@@ -13,7 +13,7 @@ type SimplicialComplex
 
 
 
-function SimplicialComplex(ListOfWords::Array{Array{TheIntegerType,1},1})
+function SimplicialComplex(ListOfWords::Vector)
         if isempty(ListOfWords)||(ListOfWords==Any[]) # This is the case of the void (or null) Complex
             new(Array{CodeWord}(0),Array{Int}(0),-2,0,emptyset)
         elseif (ListOfWords==Any[[]])||(ListOfWords==[emptyset]) #  the irrelevant complex with empty vertex set
@@ -35,27 +35,27 @@ function SimplicialComplex(ListOfWords::Array{Array{TheIntegerType,1},1})
         end
     end
 
-# The function below is identical to the above, except for the type of the input. In the future one needs to find a more elegant julia solution
-function SimplicialComplex(ListOfWords::Array{Array{Int,1},1})
-  if isempty(ListOfWords)||(ListOfWords==Any[]) # This is the case of the void (or null) Complex
-      new(Array{CodeWord}(0),Array{Int}(0),-2,0,emptyset)
-  elseif (ListOfWords==Any[[]])||(ListOfWords==[emptyset]) #  the irrelevant complex with empty vertex set
-      new([emptyset],[-1],-1,1,emptyset)
-  else
-      ## refine the list of words to a list of sets (to eliminate redundant vertices)
-      facets=map(CodeWord,ListOfWords);
-      DeleteRedundantFacets!(facets);
-      ## union one by one the entries of facets using for loop
-      vertices=emptyset
-      for i=1:length(facets)
-          vertices=union(vertices, facets[i])
-      end
-      ## dimensions is the array of dimensions of each words in facets
-      dimensions=Int[length(facets[i])-1 for i=1:length(facets)]
-      dim=length(facets[end])-1
-      Nwords=length(facets)
-      new(facets, dimensions, dim, Nwords, vertices)
-  end
-end
+# # The function below is identical to the above, except for the type of the input. In the future one needs to find a more elegant julia solution
+# function SimplicialComplex(ListOfWords::Array{Array{Int,1},1})
+#   if isempty(ListOfWords)||(ListOfWords==Any[]) # This is the case of the void (or null) Complex
+#       new(Array{CodeWord}(0),Array{Int}(0),-2,0,emptyset)
+#   elseif (ListOfWords==Any[[]])||(ListOfWords==[emptyset]) #  the irrelevant complex with empty vertex set
+#       new([emptyset],[-1],-1,1,emptyset)
+#   else
+#       ## refine the list of words to a list of sets (to eliminate redundant vertices)
+#       facets=map(CodeWord,ListOfWords);
+#       DeleteRedundantFacets!(facets);
+#       ## union one by one the entries of facets using for loop
+#       vertices=emptyset
+#       for i=1:length(facets)
+#           vertices=union(vertices, facets[i])
+#       end
+#       ## dimensions is the array of dimensions of each words in facets
+#       dimensions=Int[length(facets[i])-1 for i=1:length(facets)]
+#       dim=length(facets[end])-1
+#       Nwords=length(facets)
+#       new(facets, dimensions, dim, Nwords, vertices)
+#   end
+# end
 
 end

--- a/src/SimplicialComplexes/SimplicialComplex.jl
+++ b/src/SimplicialComplexes/SimplicialComplex.jl
@@ -75,6 +75,9 @@ end
 function eltype(::SimplicialComplex)
   return CodeWord
 end
+function eltype(::Type{SimplicialComplex})
+  return CodeWord
+end
 function length(SC::SimplicialComplex)
   return length(SC.facets)
 end

--- a/src/SimplicialComplexes/SimplicialComplex.jl
+++ b/src/SimplicialComplexes/SimplicialComplex.jl
@@ -59,3 +59,22 @@ function SimplicialComplex(ListOfWords::Vector)
 # end
 
 end
+
+#################
+# ITERATION
+#################
+function start(SC::SimplicialComplex)
+  return 1
+end
+function next(SC::SimplicialComplex, state)
+  return (SC.facets[state], state+1)
+end
+function done(SC::SimplicialComplex, state)
+  return state > length(SC.facets)
+end
+function eltype(::SimplicialComplex)
+  return CodeWord
+end
+function length(SC::SimplicialComplex)
+  return length(SC.facets)
+end

--- a/src/utilities/SC2CC_and_CC2SC.jl
+++ b/src/utilities/SC2CC_and_CC2SC.jl
@@ -8,7 +8,7 @@
 function CombinatorialCode(SC::SimplicialComplex)
     CC=[]
     for i=1:SC.Nwords
-        for j=1:length(SC.facets[i])
+        for j=0:length(SC.facets[i])
             Subsets_of_ithfacet=collect(combinations(collect(SC.facets[i]), j))
             append!(CC, Subsets_of_ithfacet)
         end

--- a/src/utilities/link_function_SC_and_CC.jl
+++ b/src/utilities/link_function_SC_and_CC.jl
@@ -27,24 +27,41 @@ end
 #####################################################################################################
 
 ## this function computes the link of a sub-codeword in a combinatorial code
-function link(C::CombinatorialCode, sigma::Set{Int})
-    ## for testing validity of sigma,
-    ## build an array Codeword_test, if sigma is contained in a facet, push the facet into the array
-    Codeword_test=[]
-    for i=1:C.Nwords
-        if issubset(sigma,C.words[i])
-                push!(Codeword_test, C.words[i])
-        end
-    end
+# function link(C::CombinatorialCode, sigma::Set{Int})
+#     ## for testing validity of sigma,
+#     ## build an array Codeword_test, if sigma is contained in a facet, push the facet into the array
+#     Codeword_test=[]
+#     for i=1:C.Nwords
+#         if issubset(sigma,C.words[i])
+#                 push!(Codeword_test, C.words[i])
+#         end
+#     end
+#
+#     ## if Simplex_test is empty, sigma is not a simplex
+#     ## else do setdiff for each collected facet, giving link
+#     if Codeword_test==[]
+#         println("ERROR!! $sigma is not a sub-codeword.")
+#     else
+#         for i=1:length(Codeword_test)
+#             Codeword_test[i]=collect(setdiff(Codeword_test[i],sigma))
+#         end
+#         CombinatorialCode(Any(Codeword_test))
+#     end
+# end
 
-    ## if Simplex_test is empty, sigma is not a simplex
-    ## else do setdiff for each collected facet, giving link
-    if Codeword_test==[]
-        println("ERROR!! $sigma is not a sub-codeword.")
-    else
-        for i=1:length(Codeword_test)
-            Codeword_test[i]=collect(setdiff(Codeword_test[i],sigma))
-        end
-        CombinatorialCode(Any(Codeword_test))
-    end
+"""
+    link(C::CombinatorialCode, sigma, tau=[])
+
+Computes the link of `C` with respect to `sigma`. If `tau` is nonempty, only
+returns codewords disjoint from tau. If no codewords `c` satisfy `sigma ⊆ c` and
+`tau ∩ c = ∅`, prints a warning message and does not return any value.
+
+"""
+function link(C::CombinatorialCode, sigma, tau=[])
+  new_words = filter(c -> issubset(sigma, c) && (isempty(tau) || isempty(intersect(tau, c))), C)
+  if isempty(new_words)
+    println("ERROR!! $sigma is not a sub-codeword, and/or ($sigma,$tau) is a combinatorial relation")
+  else
+    return CombinatorialCode([setdiff(c, sigma) for c in new_words])
+  end
 end


### PR DESCRIPTION
1. `CombinatorialCode` and `SimplicialComplex` no longer require weirdness of `Any`, i.e. `C = CombinatorialCode([[], [1,2], [1,3], [2,4]])` works as expected.
2. Bug fix: constructing `CombinatorialCode` from `SimplicialComplex` no longer omits empty set
3. Iteration interface: Can now loop over codewords of `CombinatorialCode` or facets of `SimplicialComplex` using standard syntax: e.g. `for c in C` or `for F in K`. See https://docs.julialang.org/en/release-0.5/manual/interfaces/
4. `link` now accepts optional third argument `tau` to take link w.r.t. "off" vertices. This is equivalent to taking link of bipartite complex of C, where `tau` represents the "y" vertices.