### PR TITLE
Iterator fix

### DIFF
--- a/src/CombinatorialCodes/CombinatorialCodes.jl
+++ b/src/CombinatorialCodes/CombinatorialCodes.jl
@@ -9,16 +9,16 @@ abstract type AbstractCombinatorialCode{T} <: AbstractFiniteSetCollection{T} end
 ### Generic implementations of basic operations
 ################################################################################
 ### This funcion is broken in Julia 1 please fix!
-# function show(io::IO, C::AbstractCombinatorialCode)
-#    if !get(io, :compact, false)
-#        println(io, typeof(C))
-#    end
-#    print(io, "Code on [$(maximum(vertices(C)))] with $(length(C)) codewords")
-#    if !get(io, :compact, false)
-#        println(io)
-#        println(io, "C = {$(join(C, ", "))}")
-#    end
-# end
+function show(io::IO, C::AbstractCombinatorialCode)
+   if !get(io, :compact, false)
+       println(io, typeof(C))
+   end
+   print(io, "Code on [$(maximum(vertices(C)))] with $(length(C)) codewords")
+   if !get(io, :compact, false)
+       println(io)
+       println(io, "C = {$(join(C, ", "))}")
+   end
+end
 
 ################################################################################
 ### CombinatorialCode

--- a/src/CombinatorialCodes/CombinatorialCodes.jl
+++ b/src/CombinatorialCodes/CombinatorialCodes.jl
@@ -254,19 +254,33 @@ isirrelevant(code::CombinatorialCode)=(code.words==[emptyset])
 eltype(::CombinatorialCode{T}) where T = Set{T}
 eltype(::Type{CombinatorialCode{T}}) where T = Set{T}
 length(CC::CombinatorialCode) = length(CC.words)
-start(CC::CombinatorialCode) = 1
-next(CC::CombinatorialCode, state) = (CC.words[state], state+1)
-done(CC::CombinatorialCode, state) = state > length(CC.words)
+
+###### Julia v0.6 iteration interface:
+# start(CC::CombinatorialCode) = 1
+# next(CC::CombinatorialCode, state) = (CC.words[state], state+1)
+# done(CC::CombinatorialCode, state) = state > length(CC.words)
+
+###### Julia v0.7+ iteration interface:
+iterate(CC::CombinatorialCode, state=1) = state > length(CC.words) ? nothing : (CC.words[state], state+1)
 
 ###### Iteration over maximal codewords
 length(maxC::MaximalSetIterator{CombinatorialCode{T}}) where T = length(maxC.collection.maximal_idx)
-start(maxC::MaximalSetIterator{CombinatorialCode{T}}) where T = 1
-function next(maxC::MaximalSetIterator{CombinatorialCode{T}}, state) where T
+###### Julia v0.6 iteration interface:
+# start(maxC::MaximalSetIterator{CombinatorialCode{T}}) where T = 1
+# function next(maxC::MaximalSetIterator{CombinatorialCode{T}}, state) where T
+#     C = maxC.collection
+#     return (C.words[C.maximal_idx[state]], state+1)
+# end
+# done(maxC::MaximalSetIterator{CombinatorialCode{T}}, state) where T = state > length(maxC.collection.maximal_idx)
+
+###### Julia v0.7+ iteration interface:
+function iterate(maxC::MaximalSetIterator{CombinatorialCode{T}}, state=1) where T
+    if state > length(maxC.collection.maximal_idx)
+        return nothing
+    end
     C = maxC.collection
     return (C.words[C.maximal_idx[state]], state+1)
 end
-done(maxC::MaximalSetIterator{CombinatorialCode{T}}, state) where T = state > length(maxC.collection.maximal_idx)
-
 
 
 
@@ -279,5 +293,3 @@ done(maxC::MaximalSetIterator{CombinatorialCode{T}}, state) where T = state > le
     This function is an alias to [`matrix_form`](@ref), use that instead.
 """
 BitArrayOfACombinatorialCode(C::CombinatorialCode) = matrix_form(C)
-
-

--- a/src/Simplicial.jl
+++ b/src/Simplicial.jl
@@ -8,25 +8,26 @@ import Combinatorics: combinations
 
 # methods to extend
 import Base: in, ==, <=, >=, <, >,*, show, push!, transpose, iszero,
-             start, next, done, eltype, length,
+             # start, next, done,
+             iterate, eltype, length,
              max, show,
              setdiff
 
-    # because of the changes in   julia version >=0.7 
+    # because of the changes in   julia version >=0.7
     # we introduce these backward compartibility fixes below
  if VERSION>= v"0.7.0"
        print_with_color=printstyled
        const PATHOF_Simplicial=dirname(pathof(Simplicial))
-       using DelimitedFiles, SparseArrays, LinearAlgebra, Test, Libdl, Random 
-       const Void=Nothing 
+       using DelimitedFiles, SparseArrays, LinearAlgebra, Test, Libdl, Random
+       const Void=Nothing
        full=Array
        is_linux()=Sys.islinux()
        is_windows()=Sys.iswindows()
        is_apple()=Sys.isapple()
        find=findall # make up for this horrible decision of deprecating the find function that was made under the pressure of mathworks goons
        export is_linux, is_windows, is_apple
-       
-  else 
+
+  else
   const PATHOF_Simplicial= Pkg.dir("Simplicial")*"/src"
   findall=find
   end
@@ -64,20 +65,20 @@ map(include,
      "DirectedComplexes/FiltrationOfDirectedComplexes.jl",
      "DirectedComplexes/Posets.jl",
      "DirectedComplexes/EulerCharacteristic.jl",
-    
+
      "utilities/subset_of_a_sequence.jl",
      "utilities/IntersectionsOfSequences.jl",
 
      # Filtrations Of Z2 Complexes
     "HomologyComputations/FiltrationOfZ2Complexes.jl",
      "HomologyComputations/PHAT_interface.jl",
-    
+
     # Functions testing the homology computations:
     "HomologyComputations/Test_PersistenceComputations.jl",
-    
+
     # Laplacians:
      "Laplacians/CombinatorialLaplacians.jl",
-    
+
      # utility files
      "utilities/mixed_type_operations.jl",
 
@@ -91,7 +92,9 @@ export PATHOF_Simplicial
 export
 # Imported from Base
 in, ==, <=, >=, >, <, show, push!, transpose,
-start, next, done, eltype, length,
+# start, next, done,
+iterate,
+eltype, length,
 max, show,
 setdiff,
 
@@ -117,7 +120,7 @@ union_product, intersection_completion, max_intersection_completion, union_compl
 trunk, core, delta, product, coproduct, trunksmorphism, simplexmap,
 
 # NeuralRing.jl
-Pseudomonomial, PseudoMonomialType, pseudomonomialtype, CanonicalForm, canonical_form, ==, <=, *, iszero, degree, vanishes_at, 
+Pseudomonomial, PseudoMonomialType, pseudomonomialtype, CanonicalForm, canonical_form, ==, <=, *, iszero, degree, vanishes_at,
 
 # SimplicialComplex.jl
 AbstractSimplicialComplex, SimplicialComplex,
@@ -133,7 +136,7 @@ TwoTorus, KleinBottle, PoincareHomologyThreeSphere, DunceHat,
 Bicomplex, polar_complex
 
 ###### Not yet organized
-export BettiNumbers, BettiNumbers_naive_method 
+export BettiNumbers, BettiNumbers_naive_method
 export FiltrationOfSimplicialComplexes, Skeleton, Skeleton_OLD, PersistenceIntervals, Intervals2Bettis, DowkerComplex, DowkerPersistentintervals, Sample
 export MaximalDimension, MaximalHomologicalDimension
 export PlotBettiCurves

--- a/src/Simplicial.jl
+++ b/src/Simplicial.jl
@@ -10,7 +10,7 @@ import Combinatorics: combinations
 import Base: in, ==, <=, >=, <, >,*, show, push!, transpose, iszero,
              # start, next, done,
              iterate, eltype, length,
-             max, show,
+             max,
              setdiff
 
     # because of the changes in   julia version >=0.7
@@ -95,7 +95,7 @@ in, ==, <=, >=, >, <, show, push!, transpose,
 # start, next, done,
 iterate,
 eltype, length,
-max, show,
+max,
 setdiff,
 
 # core.jl

--- a/src/SimplicialComplexes/FiltrationOfSimplicialComplexes.jl
+++ b/src/SimplicialComplexes/FiltrationOfSimplicialComplexes.jl
@@ -309,23 +309,23 @@ end# for i=1:length(FS.faces)
 
 return FiltrationOfSimplicialComplexes(ListOfFaces,birth,FS.vertices);
 end
-#  
-#  
+#
+#
 
 
 """
     show(FS::FiltrationOfSimplicialComplexes)
 """
 function show(io::IO, FS::FiltrationOfSimplicialComplexes)
-width=30;    
-number_of_vertices=length(FS.vertices); depth=FS.depth;
-print( "A fitration of $depth simplicial complexes on $number_of_vertices vertices: $(map(Int,sort(collect(FS.vertices))))\n");
-println("_"^width)
-print(  "birth time"); print(" | ") ; print( "face \n");
-println("_"^width)
-for i=1:length(FS.faces);
-   print( " $(FS.birth[i])        "); if FS.birth[i]<=9;  print(io, " "); end
-   print( "|  "); print(  "$(map(Int,sort(collect(FS.faces[i])))) \n");
- end
- println("_"^width)
+    width=30;
+    number_of_vertices=length(FS.vertices); depth=FS.depth;
+    print(io, "A filtration of $depth simplicial complexes on $number_of_vertices vertices: $(map(Int,sort(collect(FS.vertices))))\n");
+    println(io, "_"^width)
+    print(io,  "birth time"); print(io, " | ") ; print(io, "face \n");
+    println(io,"_"^width)
+    for i=1:length(FS.faces);
+        print(io, " $(FS.birth[i])        "); if FS.birth[i]<=9;  print(io, " "); end
+        print(io, "|  "); print(io,  "$(map(Int,sort(collect(FS.faces[i])))) \n");
+    end
+    println(io, "_"^width)
 end

--- a/src/SimplicialComplexes/FiltrationOfSimplicialComplexes.jl
+++ b/src/SimplicialComplexes/FiltrationOfSimplicialComplexes.jl
@@ -18,7 +18,7 @@ end # of the dumb costructor function of FiltrationOfSimplicialComplexes
   # this functions takes the list of faces together with their birth times, cleans it up (there may be redundant words), and then constructs the appropriate object
   # First we check if ListOfFaces is empty. If so then return the void complex with a bunch of empty fields
       if isempty(ListOfFaces)
-         new(Array{CodeWord}(0), Array{Int}(0), 0,  VERSION>= v"0.7.0" ? Array{Int}(undef,0) : Array{Int}(0), CodeWord([]));
+         new(Array{CodeWord}(undef, 0), Array{Int}(undef, 0), 0,  VERSION>= v"0.7.0" ? Array{Int}(undef,0) : Array{Int}(undef, 0), CodeWord([]));
       else
             # The length of ListOfFaces and that of births being different is not allowed.
             if length(ListOfFaces)!=length(births); error("The list of faces needs to be of the same length as the list of births"); end

--- a/src/SimplicialComplexes/SimplicialComplex.jl
+++ b/src/SimplicialComplexes/SimplicialComplex.jl
@@ -75,6 +75,7 @@ end
 
 
 ### ITERATION: generic iteration over _all_ faces of a complex
+### Relies on facets(K) being implemented
 function length(K::AbstractSimplicialComplex{T}) where T
     ans = 0
     for Fs in combinations(collect(facets(K)))
@@ -82,6 +83,8 @@ function length(K::AbstractSimplicialComplex{T}) where T
     end
     return ans
 end
+
+###### Julia v0.6 iteration interface:
 function start(K::AbstractSimplicialComplex{T}) where T
     #TODO subsets does not work on sets, so we have to use collect here, and then cast back
     #to Set{T} in next(). Surely there is a better way to handle this.
@@ -98,6 +101,22 @@ function next(K::AbstractSimplicialComplex{T}, state) where T
     return (Set{T}(f), (state[1], st))
 end
 done(K::AbstractSimplicialComplex{T}, state) where T = done(state[1], state[2])
+
+###### Julia v0.7+ iteration interface:
+function iterate(K::AbstractSimplicialComplex{T}) where T
+    all_subsets = map(f -> subsets(collect(f)), facets(K))
+    itr = distinct(chain(all_subsets...))
+    first, state = iterate(itr)
+    return (Set{T}(f), (itr, state))
+end
+function iterate(K::AbstractSimplicialComplex{T}, state) where T
+    # "state" is actually a tuple of an "inner" iterator and its current state; the
+    # inner iterator will return the object(s) we want as well as the next state, so
+    # we just have to unpack things, get the face and the new state, then pack it
+    # all up again.
+    (f, st) = iterate(state[1], state[2])
+    return (Set{T}(f), (state[1], st))
+end
 
 ################################################################################
 ### type SimplicialComplex
@@ -274,6 +293,10 @@ end
 
 ###### Iteration over facets: SimplicialComplex
 length(maxK::MaximalSetIterator{T}) where {T <: SimplicialComplex} = length(maxK.collection.facets)
-start(maxK::MaximalSetIterator{T}) where {T <: SimplicialComplex} = 1
-next(maxK::MaximalSetIterator{T}, state) where {T <: SimplicialComplex} = (maxK.collection.facets[state], state+1)
-done(maxK::MaximalSetIterator{T}, state) where {T <: SimplicialComplex} = state > length(maxK.collection.facets)
+###### Julia v0.6 iteration interface:
+# start(maxK::MaximalSetIterator{T}) where {T <: SimplicialComplex} = 1
+# next(maxK::MaximalSetIterator{T}, state) where {T <: SimplicialComplex} = (maxK.collection.facets[state], state+1)
+# done(maxK::MaximalSetIterator{T}, state) where {T <: SimplicialComplex} = state > length(maxK.collection.facets)
+
+###### Julia v0.7+ iteration interface:
+iterate(maxK::MaximalSetIterator{T}, state=1) where {T <: SimplicialComplex} = state > length(maxK.collection.facets) ? nothing : (maxK.collection.facets[state], state+1)


### PR DESCRIPTION
Should fix #25, fix #26, fix #27 

Also, fixed a strange bug where `show(F)` on a `FiltrationOfSimplicialComplexes` would print multiple times, and would print after every subsequent call to `show`